### PR TITLE
Update manifest.json

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Google Cloud Console Production Warning",
   "description": "Show a warning when viewing a production environment in the Google Cloud Console, Datastore admin or Stackdriver.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "permissions": [
     "activeTab",
     "storage"
@@ -30,5 +30,5 @@
       ]
     }
   ],
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
### Description
Google is phasing out Chrome Extension Manifest V2, causing the extension to be removed from the store.
A version change is needed to comply with Manifest V3 and a pull request has been submitted as a reminder for republishing the extension in the store.
https://developer.chrome.com/docs/extensions/mv3/intro/